### PR TITLE
Fix for CTD crash when Brundor is gone from the workshop.

### DIFF
--- a/RoT/BAF/rr3101.BAF
+++ b/RoT/BAF/rr3101.BAF
@@ -9,6 +9,7 @@ END
 
 IF
 	Global("StartForging","RR3101",1)
+	Exists("Brundor")
 	InActiveArea("Brundor")
 THEN
 	RESPONSE #100
@@ -20,6 +21,7 @@ END
 
 IF
 	Global("StartForging","RR3101",1)
+	Exists("Brundor2")
 	InActiveArea("Brundor2")
 THEN
 	RESPONSE #100


### PR DESCRIPTION
InActiveArea trigger works only for exisitng object, so adding "Exists" trigger fixes the issue.