### PR TITLE
The Cult of the Beast quest: fix infinite cutscene mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ This component requires the main component to be installed. It installs the foll
 - Region of Terror Kits can be installed along with TDD kits now.
 - Fixed CTDs for oBG2 areas: RA4305, RR3101, RR3700.
 - Fixed incorrect dialog condition of Mednor in "Clob's son missing" quest.
+- Fixed infinietly Cut Scene mode in "Cult of the Beast" quest.
 - Restored small NPC portraits for oBG2.
 - Traified Cadderly's name and missing string-refs.
 - Restored translated oBG2 GUI titles.

--- a/RoT/BAF/CULTBE1.BAF
+++ b/RoT/BAF/CULTBE1.BAF
@@ -2,8 +2,6 @@ IF
 	Global("Talk","LOCALS",0)
 THEN
 	RESPONSE #100
-		StartCutSceneMode()
-		HideGUI()
 		SmallWait(5)
 		FaceObject(Player1)
 		ActionOverride("CultBe2",FaceObject(Player1))


### PR DESCRIPTION
After entering the cult's underground, there is a talk with a cult member and after that you can fight or join them. However, due to a bug in a script, the player cannot see GUI because Cut Scene mode is set infinitely.