### PR TITLE
Fix for Bremen exit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ This component requires the main component to be installed. It installs the foll
 - Journal system for EE games.
 - Fixed CTDs for oBG2 areas: RA3750, RA4305, RR0044, RR3101, RR3105, RR3403, RR3700.
 - Fixed hung issue when mage (other than PC) is selected for battle area.
+- Fixed Bremen exit 
 - Fixed incorrect dialog condition of Mednor in "Clob's son missing" quest.
 - Fixed incorrect actor name of Rodger in "Clob's son missing" quest.
 - Fixed infinietly Cut Scene mode in "Cult of the Beast" quest.

--- a/RoT/BAF/5100TRA.BAF
+++ b/RoT/BAF/5100TRA.BAF
@@ -1,10 +1,7 @@
 IF
 	Clicked([ANYONE])
-	OR(3)
-		Global("Youcanleavenow","GLOBAL",0)
-		!Global("Youcanleavenow2","GLOBAL",0)
-		!Global("Youcanleavenow3","GLOBAL",0)
 	InParty("Driz2")
+	Global("Youcanleavenow","GLOBAL",0) // Drizzt hasn't spoken with Fenedon
 THEN
 	RESPONSE #100
 		ClearAllActions()

--- a/RoT/BAF/BREFI1.BAF
+++ b/RoT/BAF/BREFI1.BAF
@@ -1,8 +1,4 @@
 IF
-	OR(3)
-		!Global("Youcanleavenow","GLOBAL",0)
-		!Global("Youcanleavenow2","GLOBAL",0)
-		!Global("Youcanleavenow3","GLOBAL",0)
 	Global("Openthegate","RA5100",0)
 	CombatCounter(0)
 	OR(6)

--- a/RoT/D/BREFI7.d
+++ b/RoT/D/BREFI7.d
@@ -1,10 +1,6 @@
 BEGIN ~BREFI7~
 
-IF ~Global("Openthegate","RA5100",0)
-	OR(3)
-	!Global("Youcanleavenow","GLOBAL",0)
-	!Global("Youcanleavenow2","GLOBAL",0)
-	!Global("Youcanleavenow3","GLOBAL",0)~ THEN BEGIN 0
+IF ~Global("Openthegate","RA5100",0)~ THEN BEGIN 0
   SAY @0
   IF ~~ THEN GOTO 1
 END

--- a/RoT/D/DRIZ2J.d
+++ b/RoT/D/DRIZ2J.d
@@ -939,7 +939,8 @@ END
 
 IF ~~ THEN BEGIN 169 // from: 168.0
   SAY @238
-  IF ~~ THEN DO ~SetGlobal("Dweaponquest","GLOBAL",1)~ UNSOLVED_JOURNAL @572915 EXIT
+  IF ~~ THEN DO ~SetGlobal("Dweaponquest","GLOBAL",1)
+  SetGlobal("Youcanleavenow","GLOBAL",1)~ UNSOLVED_JOURNAL @572915 EXIT
 END
 
 IF ~Global("Seethemayor","GLOBAL",1)~ THEN BEGIN 170


### PR DESCRIPTION
The backstory is that Drizzt is always complaining about talking to Fenedon before leaving Bremen. He does it even after talking to Fenedon... and the guards would not let you pass until you get some quests. So the proposed solution is:

- Guards will open the gate without a need to collect any quests.
- Drizzt will talk about Fenedon only if it has not happened.