### PR TITLE
Adjusted ENTJAR1 cutscene coordinates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,8 +322,9 @@ This component requires the main component to be installed. It installs the foll
 - Used mod version of the spells' names for classic engine.
 - Moved area-related sounds to non-localized directory.
 - Removed RoT abbreviation from Worldmap tooltip.
-- Corrected Egidus dialog to not mention Artemis & Jarlaxle after final battle (based on Roxanne's version).
 - Renamed variable name conflicted with variable from Umar Hills (based on Roxanne's version).
+- Fixed player coordinates after first cutscene (based on Roxanne's version).
+- Corrected Egidus dialog to not mention Artemis & Jarlaxle after final battle (based on Roxanne's version).
 - Fixed stringrefs of Westchar store's drinks (based on Roxanne's version).
 - Fixed Bremen Villager conversation logic (based on Roxanne's version).
 - Reduced wait time to 2 hours for Tresham in "Escaped Prisoner" quest (based on Roxanne's version).

--- a/RoT/BAF/ENTJAR1.BAF
+++ b/RoT/BAF/ENTJAR1.BAF
@@ -85,7 +85,7 @@ THEN
 		ActionOverride("Enteri2",DestroySelf())
 		ActionOverride("Jarlxle2",DestroySelf())
 		Wait(1)
-		LeaveAreaLUA("ar0602","",[3745.2799],0)
+		LeaveAreaLUA("ar0602","",[3129.2872],7)
 		MultiPlayerSync()
 		EndCutSceneMode()
 		UnhideGUI()


### PR DESCRIPTION
Cutscene starts after PC grabs a prison key from the table. However after the cutscene, PC teleports to the their cage. This changes coords to be near the table.