### PR TITLE
Extended time for Ultima Master looting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,8 @@ This component requires the main component to be installed. It installs the foll
 - Fixed stringrefs of Westchar store's drinks (based on Roxanne's version).
 - Fixed Bremen Villager conversation logic (based on Roxanne's version).
 - Reduced wait time to 2 hours for Tresham in "Escaped Prisoner" quest (based on Roxanne's version).
-- Restored missing rest movies for RR3117 (based on Roxanne's version)
+- Extended looting time of Ultima Master (based on Roxanne's version).
+- Restored missing rest movies for RR3117 (based on Roxanne's version).
 
 ##
 

--- a/RoT/BAF/RA3014.BAF
+++ b/RoT/BAF/RA3014.BAF
@@ -44,9 +44,21 @@ END
 IF
 	Global("UltFight","GLOBAL",1)
 	Dead("UltimM") // Emanath
-	Delay(30)
+	Global("UltmM","RA3014",1)
 THEN
 	RESPONSE #100
+		SetGlobal("UltmM","RA3014",2)
+		RealSetGlobalTimer("Ultloot","RA3014",45)
+	END
+
+IF
+	Global("UltmM","RA3014",2)
+	OR(2)
+		RealGlobalTimerExpired("Ultloot","RA3014")
+		PartyHasItem("ultimas")
+THEN
+	RESPONSE #100
+		SetGlobal("UltmM","RA3014",3)
 		ScreenShake([542.303],60)
 		Wait(1)
 		HideGUI()


### PR DESCRIPTION
Party is teleported when 45 seconds elapsed or the party loot items.